### PR TITLE
Patch compilation on virtme-ng, kernel 6.9-rc6

### DIFF
--- a/mod/hook.c
+++ b/mod/hook.c
@@ -59,13 +59,13 @@ static struct jool_globals cfg = {
 	.compute_udp_csum_zero = false,
 };
 
-int joolif_open(struct net_device *dev)
+static int joolif_open(struct net_device *dev)
 {
 	netif_start_queue(dev);
 	return 0;
 }
 
-int joolif_stop(struct net_device *dev)
+static int joolif_stop(struct net_device *dev)
 {
 	netif_stop_queue(dev);
 	return 0;
@@ -83,7 +83,7 @@ static void send_packet(struct sk_buff *skb, struct net_device *dev)
 	}
 }
 
-int joolif_start_xmit(struct sk_buff *in, struct net_device *dev)
+static int joolif_start_xmit(struct sk_buff *in, struct net_device *dev)
 {
 	struct xlation state;
 

--- a/mod/xlat/rfc7915.c
+++ b/mod/xlat/rfc7915.c
@@ -2784,7 +2784,7 @@ static void ttp64_icmp_err(struct xlation *state)
 	}
 
 	compute_icmp6_csum(out);
-	out->mark = skb->mark; /* IP6_REPLY_MARK(net, skb->mark); */
+	out->mark = IP6_REPLY_MARK(net, skb->mark);
 	out->protocol = htons(ETH_P_IPV6);
 
 	memset(&state->out, 0, sizeof(state->out));

--- a/mod/xlat/rfc7915.c
+++ b/mod/xlat/rfc7915.c
@@ -1,3 +1,5 @@
+#include "rfc7915.h"
+
 #include <linux/inetdevice.h>
 #include <linux/ip.h>
 #include <linux/icmp.h>
@@ -2782,7 +2784,7 @@ static void ttp64_icmp_err(struct xlation *state)
 	}
 
 	compute_icmp6_csum(out);
-	out->mark = IP6_REPLY_MARK(net, skb->mark);
+	out->mark = skb->mark; /* IP6_REPLY_MARK(net, skb->mark); */
 	out->protocol = htons(ETH_P_IPV6);
 
 	memset(&state->out, 0, sizeof(state->out));


### PR DESCRIPTION
Also, `CONFIG_NETFILTER` needs to be enabled in kernel config.