### PR TITLE
Move `struct packet` to the skb control buffer

### DIFF
--- a/mod/hook.c
+++ b/mod/hook.c
@@ -79,6 +79,7 @@ static void send_packet(struct sk_buff *skb, struct net_device *dev)
 		next = skb->next;
 		skb->next = NULL;
 		skb->dev = dev;
+		memset(skb->cb, 0, sizeof(skb->cb));
 		netif_rx(skb);
 	}
 }
@@ -87,7 +88,7 @@ static int joolif_start_xmit(struct sk_buff *in, struct net_device *dev)
 {
 	struct xlation state;
 
-	pr_info("Received a packet.\n");
+	log_debug("Received a packet.");
 
 	skb_pull(in, ETH_HLEN); /* TODO check len >= ETH_HLEN first? */
 
@@ -99,8 +100,8 @@ static int joolif_start_xmit(struct sk_buff *in, struct net_device *dev)
 	jool_xlat(&state, in);
 	dev_kfree_skb(in);
 
-	if (state.out.skb)
-		send_packet(state.out.skb, dev);
+	if (state.out)
+		send_packet(state.out, dev);
 
 	return 0;
 }
@@ -374,8 +375,8 @@ static int siit_newlink(struct net *src_net, struct net_device *dev,
  * Inherited from veth. Not actually needed; if dellink is NULL,
  * __rtnl_link_register() automatically sets it as unregister_netdevice_queue().
  *
- * If you don't add anything, probably delete this function on pr_info() purge
- * day.
+ * TODO If you don't add anything, probably delete this function on pr_info()
+ * purge day.
  */
 static void siit_dellink(struct net_device *dev, struct list_head *head)
 {

--- a/mod/xlat/address.c
+++ b/mod/xlat/address.c
@@ -113,10 +113,10 @@ int rfc6052_4to6(struct ipv6_prefix const *prefix, __be32 src,
 int siit64_addrs(struct xlation *state, __be32 *src, __be32 *dst)
 {
 	struct ipv6_prefix *pool6 = &state->cfg->pool6;
-	struct ipv6hdr *hdr6 = pkt_ip6_hdr(&state->in);
+	struct ipv6hdr *hdr6 = ipv6_hdr(state->in);
 
 	if (rfc6052_6to4(pool6, &hdr6->saddr, src) != 0) {
-		if (!pkt_is_icmp6_error(&state->in))
+		if (!pkt_is_icmp6_error(state->in))
 			return drop(state);
 		*src = state->cfg->pool6791v4.s_addr;
 	}
@@ -132,7 +132,7 @@ int siit46_addrs(struct xlation *state, struct in6_addr *src,
 		 struct in6_addr *dst)
 {
 	struct ipv6_prefix *pool6 = &state->cfg->pool6;
-	struct iphdr *hdr4 = pkt_ip4_hdr(&state->in);
+	struct iphdr *hdr4 = ip_hdr(state->in);
 
 	if (rfc6052_4to6(pool6, hdr4->saddr, src) != 0)
 		return drop(state);

--- a/mod/xlat/translation_state.h
+++ b/mod/xlat/translation_state.h
@@ -22,9 +22,9 @@ struct xlation {
 	struct jool_globals *cfg;
 
 	/* The original packet. */
-	struct packet in;
+	struct sk_buff *in;
 	/* The translated version of @in. */
-	struct packet out;
+	struct sk_buff *out;
 
 	struct xlation_result result;
 };


### PR DESCRIPTION
This was always in the radar (`struct packet` being exactly the kind of data the control buffer was meant to store), but I couldn't do it in Netfilter, because the control buffer was apparently taken.

`struct packet` is now named `struct jool_cb`.